### PR TITLE
restricting github actions workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,7 +1,9 @@
 name: Pre-commit Hooks
 
 # whenever there is new changes pushed on this repo, run the below jobs
-on: [push]
+on:
+  pull_request:
+
 
 jobs:
   build:


### PR DESCRIPTION
restricting github actions workflow to only be triggered on branches with an open PR